### PR TITLE
Prefer /dev/urandom over /dev/random

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -95,8 +95,8 @@ random_seed (void)
 	unsigned int   seed;
 
 	if ((fd = open("/dev/hwrng", O_RDONLY)) >= 0 ||
-	    (fd = open("/dev/random", O_RDONLY)) >= 0 ||
-	    (fd = open("/dev/urandom", O_RDONLY)) >= 0)
+	    (fd = open("/dev/urandom", O_RDONLY)) >= 0 ||
+	    (fd = open("/dev/random", O_RDONLY)) >= 0)
 	{
 		read (fd, &seed, sizeof(seed));
 		close (fd);


### PR DESCRIPTION
This prevents macchanger from draining the entropy pool during boot